### PR TITLE
add tutorials

### DIFF
--- a/gensidebar.py
+++ b/gensidebar.py
@@ -72,6 +72,7 @@ def generate_sidebar(conf, conf_api):
     write('Installation', 'installation')
     write("Component Overview", 'overview')
     write('Benchmarking Tasks', 'benchmark-tasks')
+    write('Tutorials', 'tutorials')
     endl()
 
     toctree('Components')

--- a/tutorials.rst
+++ b/tutorials.rst
@@ -1,0 +1,11 @@
+================
+Tutorials
+================
+
+.. _Blog: https://mlbench.github.io/blog/
+
+You can find tutorials on how to use MLBench on our Blog_:
+
+* `Google Cloud Tutorial <https://mlbench.github.io/2018/09/10/tutorial/>`_
+* `Adding an existing Pytorch model to an MLBench task <https://mlbench.github.io/2018/11/20/pytorch-adaptation-tutorial/>`_
+* `Using the MLBench command-line interface <https://mlbench.github.io/2019/11/11/mlbench-cli/>`_


### PR DESCRIPTION
Addresses #18, adds a "Tutorials" subsection to the sidebar, with links to the blog tutorials.