### PR TITLE
Remove old instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
-===============================================
-mlbench: Distributed Machine Learning Benchmark
-===============================================
+***********************************************
+MLBench: Distributed Machine Learning Benchmark
+***********************************************
 
 .. image:: https://travis-ci.com/mlbench/mlbench-core.svg?branch=develop
     :target: https://travis-ci.com/mlbench/mlbench-core
@@ -30,7 +30,7 @@ A public and reproducible collection of reference implementations and benchmark 
 
 
 Features
---------
+########
 
 * For reproducibility and simplicity, we currently focus on standard **supervised ML**, including standard deep learning tasks as well as classic linear ML models.
 * We provide **reference implementations** for each algorithm, to make it easy to port to a new framework.
@@ -41,7 +41,7 @@ Features
 
 
 Repositories
-------------
+############
 MLBench consists of 5 Github repositories:
 
 * Documentation: http://github.com/mlbench/mlbench-docs
@@ -52,8 +52,7 @@ MLBench consists of 5 Github repositories:
 
 
 Community
----------
-
+#########
 
 Mailing list: https://groups.google.com/d/forum/mlbench
 

--- a/benchmark-tasks.rst
+++ b/benchmark-tasks.rst
@@ -1,6 +1,5 @@
 .. _benchmark-tasks:
 
-===============
 Benchmark Tasks
 ===============
 
@@ -73,7 +72,7 @@ Image classification is one of the most important problems in computer vision an
     airplanes, cars, birds, cats, deer, dogs, frogs, horses, ships, and trucks.
 
     The train / test split as provided in the dataset is used.
-    The test dataset contains 10,000 imagest with exactly 1000 randomly-selected images per each class.
+    The test dataset contains 10,000 images with exactly 1000 randomly-selected images per each class.
     The rest 50,000 images are training samples.
 
 #. **Training Algorithm**
@@ -247,7 +246,7 @@ Implementation details:
     Since ``float16`` has lower precision than ``float32``, it is necessary to have a loss scaler:
 
         - Start with ``loss_scale = initial_scale``
-        - Before each backward pass, inflate the loss by ``loss_scale`` (in ``float16``) to avoid underflows
+        - Before each backward pass, inflate the loss by ``loss_scale`` (in ``float16``) to avoid under-flows
         - Before weight update, deflate gradients by ``loss_scale`` (in ``float32``) to keep precision
         - Clip gradient norm to be ``grad_clip``
         - Check if gradient norm is ``nan`` or ``inf`` (in ``float16``). If True, ``loss_scale = loss_scale / scale_factor``.
@@ -317,7 +316,7 @@ Implementation details:
     - Loss Scaling
 
       + ``initial_scale = 2**7``
-      + ``scale_factor = 2`` (dowscale and upscale)
+      + ``scale_factor = 2`` (downscale and upscale)
       + ``scale_window = 2000`` (steps after upscale if no overflow/underflow)
 
 
@@ -334,7 +333,7 @@ Implementation details:
     Since ``float16`` has lower precision than ``float32``, it is necessary to have a loss scaler:
 
         - Start with ``loss_scale = initial_scale``
-        - Before each backward pass, inflate the loss by ``loss_scaling`` (in ``float16``) to avoid underflows
+        - Before each backward pass, inflate the loss by ``loss_scaling`` (in ``float16``) to avoid under-flows
         - Before weight update, deflate gradients by ``loss_scaling * full_batch_size / (world_size * update_freq)`` (in ``float32``) to keep precision, where ``full_batch_size`` is the batch size over all workers (sum of number of tokens on this batch for each worker).
         - Check if gradient norm is ``nan`` or ``inf`` (in ``float16``). If True, ``loss_scale = loss_scale / scale_factor``.
           If False, update weights.

--- a/installation.rst
+++ b/installation.rst
@@ -59,11 +59,15 @@ Once created, experiments can be run using:
 
    Benchmark:
 
-   [0] PyTorch Cifar-10 ResNet-20 Open-MPI
-   [1] PyTorch Cifar-10 ResNet-20 Open-MPI (SCaling LR)
-   [2] PyTorch Linear Logistic Regrssion Open-MPI
-   [3] Tensorflow Cifar-10 ResNet-20 Open-MPI
-   [4] Custom Image
+    [0]     PyTorch Cifar-10 ResNet-20
+    [1]     PyTorch Cifar-10 ResNet-20 (Scaling LR)
+    [2]     PyTorch Linear Logistic Regression
+    [3]     PyTorch Machine Translation GNMT
+    [4]     PyTorch Machine Translation Transformer
+    [5]     Tensorflow Cifar-10 ResNet-20 Open-MPI
+    [6]     PyTorch Distributed Backend benchmarking
+    [7]     Custom Image
+
 
    Selection [0]: 1
 

--- a/installation.rst
+++ b/installation.rst
@@ -5,19 +5,43 @@ Installation
 
 Make sure to read :doc:`prerequisites` before installing mlbench.
 
-Automated Setup
----------------
-
-MLBench can be installed automatically using the MLBench CLI.
-
-Install the CLI:
+Then, the library can be installed directly using ``pip``:
 
 .. code-block:: bash
 
    $ pip install mlbench-core
 
+This will add the ``mlbench`` CLI to the current environment, and will allow creation/deletion of clusters, as well as creating runs.
 
-Then you can create a cluster by running:
+.. code-block:: bash
+
+   $ mlbench --help
+      Usage: mlbench [OPTIONS] COMMAND [ARGS]...
+
+      Console script for mlbench_cli.
+
+      Options:
+        --version  Print mlbench version
+        --help     Show this message and exit.
+
+      Commands:
+        charts             Chart the results of benchmark runs Save generated...
+        create-cluster     Create a new cluster.
+        delete             Delete a benchmark run
+        delete-cluster     Delete a cluster.
+        download           Download the results of a benchmark run
+        get-dashboard-url  Returns the dashboard URL of the current cluster
+        list-clusters      List all currently configured clusters.
+        run                Start a new run for a benchmark image
+        set-cluster        Set the current cluster to use.
+        status             Get the status of a benchmark run, or all runs if no...
+
+Cluster & Run Deployment (using CLI)
+------------------------------------
+
+One can easily deploy a cluster on both AWS and GCloud, using the ``mlbench`` CLI.
+
+For example, one can create a GCloud cluster by running:
 
 .. code-block:: bash
 
@@ -27,7 +51,7 @@ Then you can create a cluster by running:
 
 Which creates a cluster called ``my-cluster-3`` with 3 nodes (See ``mlbench create-cluster gcloud --help`` for more options).
 
-Once created, you can run experiments with:
+Once created, experiments can be run using:
 
 .. code-block:: bash
 
@@ -47,59 +71,77 @@ Once created, you can run experiments with:
 
    Run started with name my-run-2
 
-See ``mlbench run --help`` for more options.
+A few handy commands for quickstart:
 
-You can access the dashboard with ``mlbench get-dashboard-url``.
-
-To see the state of the experiment, run ``mlbench status my-run-2``.
-
-To download the results of the experiment, run ``mlbench download my-run-2``.
-
-Don't forget to delete the cluster once you're done by running ``mlbench delete-cluster gcloud my-cluster-3``
-
-Manual Setup
-------------
-The manual setup assumes you have checked out the `mlbench-helm <https://github.com/mlbench/mlbench-helm>`__ github repository and have a terminal open in the checked-out ``mlbench-helm`` directory.
-
-.. _google-cloud-setup:
-
-Google Cloud and Cluster Setup
-""""""""""""""""""""""""""""""
-
-This project provides a script to make all the Google Cloud and Cluster setup. In order to do so, please run the following commands:
-
-.. code-block:: bash
-
-    $ ./google_cloud_setup.sh create-cluster
-    $ ./google_cloud_setup.sh install-chart
-
-
-To delete cluster and cleanup:
-
-.. code-block:: bash
-
-    $ ./google_cloud_setup.sh delete-cluster
-
-To uninstall chart:
-
-.. code-block:: bash
-
-    $ ./google_cloud_setup.sh uninstall-chart
-
-For general information on the available commands, please run:
-
-.. code-block:: bash
-
-    $ ./google_cloud_setup.sh help
-
+ - To obtain the dashboard URL: ``mlbench get-dashboard-url``.
+ - To see the state of the experiment: ``mlbench status my-run-2``.
+ - To download the results of the experiment: ``mlbench download my-run-2``.
+ - To delete the cluster: ``mlbench delete-cluster gcloud my-cluster-3``
 
 .. _helm-charts:
 
-Helm Chart values
-"""""""""""""""""
+Manual helm chart deployment (Optional)
+---------------------------------------
 
-Since every Kubernetes is different, there are no reasonable defaults for some values, so the following properties have to be set.
-You can save them in a yaml file of your chosing. This guide will assume you saved them in `myvalues.yaml`. For a reference file for all configurable values, you can copy the `values.yaml` file to `myvalues.yaml`.
+Helm Chart installation
+^^^^^^^^^^^^^^^^^^^^^^^
+
+The manual deployment requires the repo `mlbench-helm <https://github.com/mlbench/mlbench-helm>`_ to be cloned, and helm to be installed :ref:`helm-install`
+
+MLBench's Helm charts can also be deployed manually on a running Kubernetes cluster.
+For that, it is needed to have the credentials for the cluster in the ``kubectl`` config.
+For example, to obtain the credentials for a GCloud Kubernetes cluster, one should run
+
+.. code-block:: bash
+
+   $ gcloud container clusters get-credentials --zone ${MACHINE_ZONE} ${CLUSTER_NAME}
+
+This will setup ``kubectl`` for the cluster.
+
+Then to deploy the dashboard on the running cluster, we first need to set up helm with service-account with ``cluster-admin`` rights:
+
+.. code-block:: bash
+
+   $ kubectl --namespace kube-system create sa tiller
+   $ kubectl create clusterrolebinding tiller --clusterrole cluster-admin --serviceaccount=kube-system:tiller
+   $ helm init --service-account tiller
+
+Then, we install the chart on the cluster:
+
+.. code-block:: bash
+
+   $ cd mlbench-helm
+   $ helm upgrade --wait --recreate-pods -f values.yml \
+        --timeout 900 --install ${RELEASE_NAME} . \
+        --set limits.workers=${NUM_NODES-1} \
+        --set limits.gpu=${NUM_GPUS} \
+        --set limits.cpu=${NUM_CPUS-1}
+
+Where :
+   - ``RELEASE_NAME`` represents the cluster name (called ``my-cluster-3`` in the example above)
+   - ``NUM_NODES`` is the maximum number of worker nodes available. This sets the maximum number of nodes that can be chosen for an experiment in the UI/CLI.
+   - ``NUM_GPUS`` is the number of gpus requested by each worker pod.
+   - ``NUM_CPUS`` is the maximum number of CPUs (Cores) available on each worker node. Uses Kubernetes notation (`8` or `8000m` for 8 cpus/cores). This is also the maximum number of Cores that can be selected for an experiment in the UI
+
+This will deploy the helm charts with the corresponding images to each node, and will set the hardware limits.
+
+.. note::
+   Get the application URL by running these commands:
+    .. code-block:: bash
+
+       $ export NODE_PORT=$(kubectl get --namespace default -o jsonpath="{.spec.ports[0].nodePort}" services ${RELEASE_NAME}-mlbench-master)
+       $ export NODE_IP=$(gcloud compute instances list|grep $(kubectl get nodes --namespace default -o jsonpath="{.items[0].status.addresses[0].address}") |awk '{print $5}')
+       $ gcloud compute firewall-rules create --quiet mlbench --allow tcp:$NODE_PORT,tcp:$NODE_PORT
+       $ echo http://$NODE_IP:$NODE_PORT
+
+.. danger::
+    The last command opens up a firewall rule to the google cloud. Make sure to delete the rule once it's not needed anymore:
+
+    .. code-block:: bash
+
+      $ gcloud compute firewall-rules delete --quiet mlbench
+
+One can also create a new ``myvalues.yml`` file with custom limits:
 
 .. code-block:: yaml
 
@@ -119,8 +161,8 @@ You can save them in a yaml file of your chosing. This guide will assume you sav
 - ``gcePersistentDisk.pdName`` is the name of persistent disk existed in GKE.
 
 .. Caution::
-   If you set ``workers``, ``cpu`` or ``gpu`` higher than available in your cluster, Kubernetes will not be able to allocate nodes to mlbench and the deployment will hang indefinitely, without throwing an exception.
-   Kubernetes will just wait until nodes that fit the requirements become available. So make sure your cluster actually has the requirements available that you requested.
+   If ``workers``, ``cpu`` or ``gpu`` are set higher than available in the cluster, Kubernetes will not be able to allocate nodes to mlbench and the deployment will hang indefinitely, without throwing an exception.
+   Kubernetes will just wait until nodes that fit the requirements become available. So make sure the cluster actually has the requested requirements.
 
 .. note::
    To use ``gpu`` in the cluster, the `nvidia device plugin <https://github.com/NVIDIA/k8s-device-plugin>`_ should be installed. See :ref:`plugins` for details
@@ -131,134 +173,23 @@ You can save them in a yaml file of your chosing. This guide will assume you sav
 .. note::
    The GCE persistent disk will be mounted to `/datasets/` directory on each worker.
 
-Helm Install
-""""""""""""
-
-Set the :ref:`helm-charts`
-
-Use helm to install the mlbench chart (Replace ``${RELEASE_NAME}`` with a name of your choice):
-
-.. code-block:: bash
-
-   $ helm upgrade --wait --recreate-pods -f values.yaml --timeout 900 --install ${RELEASE_NAME} .
-
-Follow the instructions at the end of the helm install to get the dashboard URL. E.g.:
-
-.. code-block:: bash
-   :emphasize-lines: 5,6,7
-
-   $ helm upgrade --wait --recreate-pods -f values.yaml --timeout 900 --install rel .
-     [...]
-     NOTES:
-     1. Get the application URL by running these commands:
-        export NODE_PORT=$(kubectl get --namespace default -o jsonpath="{.spec.ports[0].nodePort}" services rel-mlbench-master)
-        export NODE_IP=$(kubectl get nodes --namespace default -o jsonpath="{.items[0].status.addresses[0].address}")
-        echo http://$NODE_IP:$NODE_PORT
-
-This outputs the URL the Dashboard is accessible at.
+.. caution::
+   Google installs several pods on each node by default, limiting the available CPU. This can take up to 0.5 CPU cores per node. So make sure to provision VM's that have at least 1 more core than the amount of cores you want to use for you mlbench experiment.
+   See `here <https://cloud.google.com/kubernetes-engine/docs/concepts/cluster-architecture#memory_cpu>`__ for further details on node limits.
 
 .. _plugins:
 
 Plugins
-"""""""
+^^^^^^^
+
 In ``values.yaml``, one can optionally install Kubernetes plugins by turning on/off the following flags:
 
 - ``weave.enabled``: If true, install the `weave network plugin <https://github.com/weaveworks/weave>`_.
 - ``nvidiaDevicePlugin.enabled``: If true, install the `nvidia device plugin <https://github.com/NVIDIA/k8s-device-plugin>`_.
 
-Google Cloud / Google Kubernetes Engine
-"""""""""""""""""""""""""""""""""""""""
-
-Set the :ref:`helm-charts`
-
-.. important::
-   Make sure to read the prerequisites for :ref:`google-cloud`
-
-Please make sure that ``kubectl`` is configured `correctly <https://cloud.google.com/kubernetes-engine/docs/quickstart>`_.
-
-.. caution::
-   Google installs several pods on each node by default, limiting the available CPU. This can take up to 0.5 CPU cores per node. So make sure to provision VM's that have at least 1 more core than the amount of cores you want to use for you mlbench experiment.
-   See `here <https://cloud.google.com/kubernetes-engine/docs/concepts/cluster-architecture#memory_cpu>`__ for further details on node limits.
-
-Install mlbench (Replace ``${RELEASE_NAME}`` with a name of your choice):
-
-.. code-block:: bash
-
-   $ helm upgrade --wait --recreate-pods -f values.yaml --timeout 900 --install ${RELEASE_NAME} .
-
-To access mlbench, run these commands and open the URL that is returned (**Note**: The default instructions returned by `helm` on the commandline return the internal cluster ip only):
-
-.. code-block:: bash
-
-   $ export NODE_PORT=$(kubectl get --namespace default -o jsonpath="{.spec.ports[0].nodePort}" services ${RELEASE_NAME}-mlbench-master)
-   $ export NODE_IP=$(gcloud compute instances list|grep $(kubectl get nodes --namespace default -o jsonpath="{.items[0].status.addresses[0].address}") |awk '{print $5}')
-   $ gcloud compute firewall-rules create --quiet mlbench --allow tcp:$NODE_PORT,tcp:$NODE_PORT
-   $ echo http://$NODE_IP:$NODE_PORT
-
-.. danger::
-   The last command opens up a firewall rule to the google cloud. Make sure to delete the rule once it's not needed anymore:
-
-   .. code-block:: bash
-
-      $ gcloud compute firewall-rules delete --quiet mlbench
-
-
-Minikube
-""""""""
-
-Minikube allows running a single-node Kubernetes cluster inside a VM on your laptop, for users looking to try out Kubernetes or to develop with it.
-
-Installing mlbench to `minikube <https://github.com/kubernetes/minikube>`_.
-
-Set the :ref:`helm-charts`
-
-.. important::
-   If you are using Kubernetes version 1.16 or higher you will need to to add the following line to `/etc/kubernetes/manifest/kube-apiserver.yaml`
-
-   .. code-block:: bash
-
-      --runtime-config=apps/v1beta1=true,apps/v1beta2=true,extensions/v1beta1/daemonsets=true,extensions/v1beta1/deployments=true,extensions/v1beta1/replicasets=true,extensions/v1beta1/networkpolicies=true,extensions/v1beta1/podsecuritypolicies=true
-
-
-Start minikube cluster
-
-.. code-block:: bash
-
-    $ minikube start
-
-
-Next install or upgrade a helm chart with desired configurations with name `${RELEASE_NAME}`
-
-.. code-block:: bash
-
-    $ helm init --kube-context minikube --wait
-    $ helm upgrade --wait --recreate-pods -f myvalues.yaml --timeout 900 --install ${RELEASE_NAME} .
-
-.. note::
-    The minikube runs a single-node Kubernetes cluster inside a VM. So we need to fix the :code:`replicaCount=1` in `values.yaml`.
-
-Once the installation is finished, one can obtain the url
-
-.. code-block:: bash
-
-    $ export NODE_PORT=$(kubectl get --namespace default -o jsonpath="{.spec.ports[0].nodePort}" services ${RELEASE_NAME}-mlbench-master)
-    $ export NODE_IP=$(kubectl get nodes --namespace default -o jsonpath="{.items[0].status.addresses[0].address}")
-    $ echo http://$NODE_IP:$NODE_PORT
-
-Now the mlbench dashboard should be available at :code:`http://${NODE_IP}:${NODE_PORT}`.
-
-.. note::
-  To access :code:`http://$NODE_IP:$NODE_PORT` outside minikube, run the following command on the host:
-
-  .. code-block:: bash
-
-      $ ssh -i ${MINIKUBE_HOME}/.minikube/machines/minikube/id_rsa -N -f -L localhost:${NODE_PORT}:${NODE_IP}:${NODE_PORT} docker@$(minikube ip)
-
-  where :code:`$MINIKUBE_HOME` is by default :code:`$HOME`. One can view mlbench dashboard at :code:`http://localhost:${NODE_PORT}`
-
 
 Kubernetes-in-Docker (KIND)
-"""""""""""""""""""""""""""
+---------------------------
 
 Kubernetes-in-Docker allows simulating multiple nodes locally on a single machine. This approach should be used only for local development and testing. It is not a recommended way to measure benchmark results. 
 

--- a/installation.rst
+++ b/installation.rst
@@ -11,7 +11,7 @@ Then, the library can be installed directly using ``pip``:
 
    $ pip install mlbench-core
 
-This will add the ``mlbench`` CLI to the current environment, and will allow creation/deletion of clusters, as well as creating runs.
+This will install the ``mlbench`` CLI to the current environment, and will allow creation/deletion of clusters, as well as creating runs.
 
 .. code-block:: bash
 
@@ -108,15 +108,14 @@ Then to deploy the dashboard on the running cluster, we first need to set up hel
 
    $ kubectl --namespace kube-system create sa tiller
    $ kubectl create clusterrolebinding tiller --clusterrole cluster-admin --serviceaccount=kube-system:tiller
-   $ helm init --service-account tiller
 
 Then, we install the chart on the cluster:
 
 .. code-block:: bash
 
    $ cd mlbench-helm
-   $ helm upgrade --wait --recreate-pods -f values.yml \
-        --timeout 900 --install ${RELEASE_NAME} . \
+   $ helm upgrade --wait --recreate-pods -f values.yaml \
+        --timeout 900s --install ${RELEASE_NAME} . \
         --set limits.workers=${NUM_NODES-1} \
         --set limits.gpu=${NUM_GPUS} \
         --set limits.cpu=${NUM_CPUS-1}

--- a/prerequisites.rst
+++ b/prerequisites.rst
@@ -75,6 +75,8 @@ Example of cluster creation:
         --machine-type=n1-standard-4 --num-nodes=2 --disk-type=pd-standard \
         --disk-size=50 --scopes=storage-full
 
+If you would like to add GPU acceleration, add the following parameter ``--accelerator type=${GPU_TYPE},count=${NUM_GPUS}``
+
 .. _helm-install:
 
 Helm (Optional)

--- a/prerequisites.rst
+++ b/prerequisites.rst
@@ -6,48 +6,91 @@ Prerequisites
 Kubernetes
 ----------
 
-mlbench uses `Kubernetes <https://kubernetes.io/>`_ as basis for the distributed cluster. This allows for easy and reproducible installation and use of the framework on a multitude of platforms.
+MLBench uses `Kubernetes <https://kubernetes.io/>`_ as basis for the distributed cluster.
+This allows for easy and reproducible installation and use of the framework on a multitude of platforms.
 
-Since mlbench manages the setup of nodes for experiments and uses Kubernetes to monitor the status of worker pods, it needs to be installed with a service-account that has permission to manage and monitor ``Pods`` and ``StatefulSets``.
+Since mlbench manages the setup of nodes for experiments and uses Kubernetes to monitor the status of worker pods,
+it needs to be installed with a service-account that has permission to manage and monitor ``Pods`` and ``StatefulSets``.
 
 Additionally, `helm` requires a kubernetes user account with the ``cluster-admin`` role to deploy applications to a kubernetes cluster.
+
+To use MLBench, one would need to install `kubectl <https://kubernetes.io/docs/tasks/tools/install-kubectl/>`_
+
+On Ubuntu/Debian:
+
+.. code-block:: bash
+
+    $ sudo apt-get update && sudo apt-get install -y apt-transport-https gnupg2
+    $ curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
+    $ echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee -a /etc/apt/sources.list.d/kubernetes.list
+    $ sudo apt-get update
+    $ sudo apt-get install -y kubectl
 
 .. _google-cloud:
 
 Google Cloud
-^^^^^^^^^^^^
+------------
 
-For Google Cloud see: `Creating a Cluster <https://cloud.google.com/kubernetes-engine/docs/how-to/creating-a-cluster>`_ and `Kubernetes Quickstart <https://cloud.google.com/kubernetes-engine/docs/quickstart>`_.
+GCloud SDK (Required)
+^^^^^^^^^^^^^^^^^^^^^
 
-Cluster setup in Google Cloud is handled by running a setup script detailed in the Installation section. Concerning this, please refer to :ref:`google-cloud-setup`.
+To use MLBench with GCLoud, it requires the `gcloud <https://cloud.google.com/sdk/install>`_ CLI to be installed and authenticated on the client machine.
 
+On Ubuntu/Debian:
+
+.. code-block:: bash
+
+    $ echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+    $ sudo apt-get install apt-transport-https ca-certificates gnupg
+    $ curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
+    $ sudo apt-get update && sudo apt-get install google-cloud-sdk
+    $ gcloud init
 
 .. note::
     In order to set you credentials for gcloud, you need to run the commands ``gcloud auth login`` and ``gcloud auth application-default login``
 
+Manually creating a cluster (Optional)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The GCloud SDK allows for `manual cluster creation <https://cloud.google.com/kubernetes-engine/docs/how-to/creating-a-cluster>`_
+Please refer to `Kubernetes Quickstart <https://cloud.google.com/kubernetes-engine/docs/quickstart>`_ for more information
+
+
+
+
 If you're planning to use GPUs in your cluster, see the `GPUs <https://cloud.google.com/kubernetes-engine/docs/how-to/gpus>`_ article, especially the "Installing NVIDIA GPU device drivers" section.
 
-When creating a GKE cluster, make sure to use version ``1.10.9`` or above of kubernetes, as there is an issue with DNS resolution in earlier version. You can do this with the ``--cluster-version=1.10.9``
+When creating a GKE cluster, make sure to use version ``1.15`` or above of kubernetes, as there is an issue with DNS resolution in earlier version.
+You can do this with the ``--cluster-version=1.15``
 flag for the ``gcloud container clusters create`` command.
 
 Make sure credentials for your cluster are installed correctly (use the correct zone for your cluster):
 
+Example of cluster creation:
+
 .. code-block:: bash
 
-   gcloud container clusters get-credentials ${CLUSTER_NAME} --zone us-central1-a
+    $ gcloud container clusters create dummy-2 --zone=europe-west1-b \
+        --cluster-version="1.15" --enable-network-policy \
+        --machine-type=n1-standard-4 --num-nodes=2 --disk-type=pd-standard \
+        --disk-size=50 --scopes=storage-full
 
-Helm
-----
+.. _helm-install:
+
+Helm (Optional)
+---------------
 
 Helm charts are like recipes to install Kubernetes distributed applications. They consist of templates with some logic that get rendered into Kubernetes deployment `.yaml` files
 They come with some default values, but also allow users to override those values.
 
-Helm can be found `here <https://github.com/helm/helm/>`_
+Helm can be found `here <https://helm.sh/docs/intro/install/>`_, and only needs to be installed if manual cluster installation is needed (i.e. manually install MLBench on a cluster)
 
-Helm needs to be set up with service-account with ``cluster-admin`` rights:
+On Ubuntu/Debian:
 
 .. code-block:: bash
 
-   kubectl --namespace kube-system create sa tiller
-   kubectl create clusterrolebinding tiller --clusterrole cluster-admin --serviceaccount=kube-system:tiller
-   helm init --service-account tiller
+    $ curl https://baltocdn.com/helm/signing.asc | sudo apt-key add -
+    $ sudo apt-get install apt-transport-https --yes
+    $ echo "deb https://baltocdn.com/helm/stable/debian/ all main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list
+    $ sudo apt-get update
+    $ sudo apt-get install helm

--- a/tutorials.rst
+++ b/tutorials.rst
@@ -1,4 +1,3 @@
-================
 Tutorials
 ================
 
@@ -6,7 +5,7 @@ Tutorials
 
 Also check out our Blog_ for good tips and the latest news!
 
-Adding an existing PyTorch training script into MLbench
+Adding an existing PyTorch training script into MLBench
 ----------------------------------------------------------
 
 In this tutorial, we will go through the process of adapting existing distributed PyTorch code to work with the MLBench framework. This allows you to run your models in the MLBench environment and easily compare them
@@ -15,10 +14,11 @@ with our reference implementations as baselines to see how well your code perfor
 MLBench is designed to easily be used with third-party models, allowing for quick and fair comparisons by standardizing the data distribution, evaluation dataset and providing evaluation code.
 It saves all of the hassle that's needed to implement your own baselines for comparison.
 
-We will adapt the code from the official `PyTorch distributed tutorial <https://pytorch.org/tutorials/intermediate/dist_tuto.html>`_ to run in MLBench. If you're unfamiliar with that tutorial, it might be worth giving it a quick look so you know what we're working with.
+We will adapt the code from the official `PyTorch distributed tutorial <https://pytorch.org/tutorials/intermediate/dist_tuto.html>`_ to run in MLBench.
+If you're unfamiliar with that tutorial, it might be worth giving it a quick look so you know what we're working with.
 
 Adapting the Code
-~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^
 
 To get started, create a new directory ``mlbench-pytorch-tutorial`` and copy the `train_dist.py <https://github.com/seba-1511/dist_tuto.pth/blob/gh-pages/train_dist.py>`_ file into it.
 
@@ -79,7 +79,8 @@ We also need to change the ``init_processes`` method to reflect our previous cha
         dist.init_process_group(backend, rank=rank, world_size=len(world_size))
         run(rank, world_size, run_id)
 
-Next, we need to change the signature of the ``run`` method to add the ``run_id`` parameter. The ``run_id`` is a unique identifier automatically assigned by MLBench to identify an individual run and all its data and performance metrics.
+Next, we need to change the signature of the ``run`` method to add the ``run_id`` parameter. The ``run_id`` is a unique identifier automatically assigned
+by MLBench to identify an individual run and all its data and performance metrics.
 
 .. code-block:: python
     :linenos:
@@ -93,7 +94,8 @@ stats during training. Results are shown either in the Dashboard (where
 you can see them in real time) or can be downloaded at any time during the 
 run from the command line. So let's add some reporting functionality.
 
-The PyTorch script reports loss to ``stdout``, but we can easily report the loss to MLBench as well. First we need to import the relevant MLBench functionality by adding the following line to the imports at the top of the file:
+The PyTorch script reports loss to ``stdout``, but we can easily report the loss to MLBench as well. First we need to import the relevant MLBench
+functionality by adding the following line to the imports at the top of the file:
 
 .. code-block:: python
     :linenos:
@@ -171,7 +173,7 @@ We have to tell the tracker that we're in the training loop by calling ``tracker
 That's it. Now the training will report the loss of each worker back to the Dashboard and the output result files. 
 On the Dashboard, you will also see a nice graph showing this data.
 
-For the official tasks, we also need to report validation stats to the tracker and use the offical validation code. Rename the current ``partition_dataset()`` method to ``partition_dataset_train``
+For the official tasks, we also need to report validation stats to the tracker and use the official validation code. Rename the current ``partition_dataset()`` method to ``partition_dataset_train``
 and add a new partition method to load the validation set:
 
 .. code-block:: python
@@ -197,7 +199,7 @@ and add a new partition method to load the validation set:
         return val_set, bsz
 
 Then load the validation set and add the goal for the official task (The `Task 1a goal <https://mlbench.readthedocs.io/en/latest/benchmark-tasks.html#a-image-classification-resnet-cifar-10>`_
-is used for illustration purposes in thsi example):
+is used for illustration purposes in this example):
 
 .. code-block:: python
     :linenos:
@@ -249,7 +251,7 @@ Now all that is needed is to add the validation loop code (``validation_round()`
 The full code (with some additional improvements) is in our `Github Repo <https://github.com/mlbench/mlbench-benchmarks/blob/master/examples/mlbench-pytorch-tutorial/>`_.
 
 Creating a Docker Image for Kubernetes
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 To actually run our code, we need to wrap it in a Docker Image. We could create one from scratch, but it's easier to use the PyTorch Base image provided by MLBench, which already includes everything you might need for executing a PyTorch model.
 
@@ -273,7 +275,7 @@ Create a new file called ``Dockerfile`` in the ``mlbench-pytorch-tutorial`` dire
 
     ENV PYTHONPATH /codes
 
-The ``mlbench-pytorch-base:latest`` image already contains all neccessary libraries, but if your image requires additional python libraries, you can add them with the commands on lines 6 and 7, along with adding a ``requirements.txt`` file.
+The ``mlbench-pytorch-base:latest`` image already contains all necessary libraries, but if your image requires additional python libraries, you can add them with the commands on lines 6 and 7, along with adding a ``requirements.txt`` file.
 
 In order for Kubernetes to access the image, you have to build and upload it to a Docker registry that's accessible to Kubernetes, for instance `Docker Hub <https://hub.docker.com/>`_ (Make sure to change the Docker image and repo name accordingly):
 
@@ -286,7 +288,7 @@ In order for Kubernetes to access the image, you have to build and upload it to 
 The image is now built and available for running in MLBench.
 
 Running the code in MLBench
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Navigate to the MLBench Dashboard and go to the ``Runs`` page.
 
@@ -371,7 +373,7 @@ To create a new Google cloud cluster, simply run (this might take a couple of mi
 
 This creates a cluster with 3 nodes called ``my-cluster-3`` and sets up the mlbench deployment in that cluster. Note that the number of nodes should always be 1 higher than the maximum number of workers you want to run.
 
-To start an experiment, simpy run:
+To start an experiment, simply run:
 
 .. code-block:: shell
 
@@ -379,13 +381,24 @@ To start an experiment, simpy run:
 
     Benchmark:
 
-    [0] PyTorch Cifar-10 ResNet-20 Open-MPI
-    [1] PyTorch Cifar-10 ResNet-20 Open-MPI (SCaling LR)
-    [2] PyTorch Linear Logistic Regrssion Open-MPI
-    [3] Tensorflow Cifar-10 ResNet-20 Open-MPI
-    [4] Custom Image
+    [0]     PyTorch Cifar-10 ResNet-20
+    [1]     PyTorch Cifar-10 ResNet-20 (Scaling LR)
+    [2]     PyTorch Linear Logistic Regression
+    [3]     PyTorch Machine Translation GNMT
+    [4]     PyTorch Machine Translation Transformer
+    [5]     Tensorflow Cifar-10 ResNet-20 Open-MPI
+    [6]     PyTorch Distributed Backend benchmarking
+    [7]     Custom Image
 
     Selection [0]: 1
+    Backend:
+
+    [0]     MPI
+    [1]     GLOO
+    [2]     NCCL
+    [3]     Custom Backend
+
+    Selection [0]: 0
 
     [...]
 
@@ -402,13 +415,25 @@ You can also start multiple runs at the same time, which will be scheduled as no
 
     Benchmark:
 
-    [0] PyTorch Cifar-10 ResNet-20 Open-MPI
-    [1] PyTorch Cifar-10 ResNet-20 Open-MPI (SCaling LR)
-    [2] PyTorch Linear Logistic Regrssion Open-MPI
-    [3] Tensorflow Cifar-10 ResNet-20 Open-MPI
-    [4] Custom Image
+    [0]     PyTorch Cifar-10 ResNet-20
+    [1]     PyTorch Cifar-10 ResNet-20 (Scaling LR)
+    [2]     PyTorch Linear Logistic Regression
+    [3]     PyTorch Machine Translation GNMT
+    [4]     PyTorch Machine Translation Transformer
+    [5]     Tensorflow Cifar-10 ResNet-20 Open-MPI
+    [6]     PyTorch Distributed Backend benchmarking
+    [7]     Custom Image
+
 
     Selection [0]: 1
+    Backend:
+
+    [0]     MPI
+    [1]     GLOO
+    [2]     NCCL
+    [3]     Custom Backend
+
+    Selection [0]: 0
 
     [...]
 
@@ -470,10 +495,3 @@ you also need to delete it by passing the same flag and argument to ``mlbench de
 
     # delete cluster
     $ mlbench delete-cluster gcloud -z europe-west2-b my-cluster-3
-
-
-
-
-
-
-


### PR DESCRIPTION
Closes #30 

- Corrects some typos and unifies RST title and subtitle hierarchy on all files.
- Removes old instructions on scripts
- Marks what parts/libraries are required/optional
- Clearly define prerequisites and installation instructions
- Instructions on manual installation of helm charts on any kubernetes cluster (theoretically)

